### PR TITLE
Update prediction type error message

### DIFF
--- a/R/predict.R
+++ b/R/predict.R
@@ -118,7 +118,7 @@ predict.ranger.forest <- function(object, data, predict.all = FALSE,
   } else if (type == "quantiles") {
     stop("Error: Apply predict() to the ranger object instead of the $forest object to predict quantiles.")
   } else {
-    stop("Error: Invalid value for 'type'. Use 'response' or 'terminalNodes'.")
+    stop("Error: Invalid value for 'type'. Use 'response', 'se', 'terminalNodes', or 'quantiles'.")
   }
   
   ## Type "se" only for certain tree types


### PR DESCRIPTION
Small fix. Error message for prediction type value did not include 'se' or 'quantiles'. Updated to list all possible 'type' values. 

I apologize if this is a waste of time. It's very very small but just something that I noticed when I accidentally used 'quantile' instead of 'quantiles'.

