### PR TITLE
Guard verbose output

### DIFF
--- a/src/Forest.cpp
+++ b/src/Forest.cpp
@@ -67,11 +67,10 @@ void Forest::initCpp(std::string dependent_variable_name, MemoryMode memory_mode
   }
 
   // Load data
-  *verbose_out << "Loading input file: " << input_file << "." << std::endl;
+  if (verbose_out) *verbose_out << "Loading input file: " << input_file << "." << std::endl;
   bool rounding_error = data->loadFromFile(input_file);
-  if (rounding_error) {
-    *verbose_out << "Warning: Rounding or Integer overflow occurred. Use FLOAT or DOUBLE precision to avoid this."
-        << std::endl;
+  if (rounding_error && verbose_out) {
+    *verbose_out << "Warning: Rounding or Integer overflow occurred. Use FLOAT or DOUBLE precision to avoid this." << std::endl;
   }
 
   // Set prediction mode
@@ -268,24 +267,24 @@ void Forest::init(std::string dependent_variable_name, MemoryMode memory_mode, D
 void Forest::run(bool verbose) {
 
   if (prediction_mode) {
-    if (verbose) {
+    if (verbose && verbose_out) {
       *verbose_out << "Predicting .." << std::endl;
     }
     predict();
   } else {
-    if (verbose) {
+    if (verbose && verbose_out) {
       *verbose_out << "Growing trees .." << std::endl;
     }
 
     grow();
 
-    if (verbose) {
+    if (verbose && verbose_out) {
       *verbose_out << "Computing prediction error .." << std::endl;
     }
     computePredictionError();
 
     if (importance_mode == IMP_PERM_BREIMAN || importance_mode == IMP_PERM_LIAW || importance_mode == IMP_PERM_RAW) {
-      if (verbose) {
+      if (verbose && verbose_out) {
         *verbose_out << "Computing permutation variable importance .." << std::endl;
       }
       computePermutationImportance();
@@ -296,31 +295,37 @@ void Forest::run(bool verbose) {
 // #nocov start
 void Forest::writeOutput() {
 
-  *verbose_out << std::endl;
+  if (verbose_out) *verbose_out << std::endl;
   writeOutputInternal();
-  *verbose_out << "Dependent variable name:           " << data->getVariableNames()[dependent_varID] << std::endl;
-  *verbose_out << "Dependent variable ID:             " << dependent_varID << std::endl;
-  *verbose_out << "Number of trees:                   " << num_trees << std::endl;
-  *verbose_out << "Sample size:                       " << num_samples << std::endl;
-  *verbose_out << "Number of independent variables:   " << num_independent_variables << std::endl;
-  *verbose_out << "Mtry:                              " << mtry << std::endl;
-  *verbose_out << "Target node size:                  " << min_node_size << std::endl;
-  *verbose_out << "Variable importance mode:          " << importance_mode << std::endl;
-  *verbose_out << "Memory mode:                       " << memory_mode << std::endl;
-  *verbose_out << "Seed:                              " << seed << std::endl;
-  *verbose_out << "Number of threads:                 " << num_threads << std::endl;
-  *verbose_out << std::endl;
+  if (verbose_out) {
+    *verbose_out << "Dependent variable name:           " << data->getVariableNames()[dependent_varID] << std::endl;
+    *verbose_out << "Dependent variable ID:             " << dependent_varID << std::endl;
+    *verbose_out << "Number of trees:                   " << num_trees << std::endl;
+    *verbose_out << "Sample size:                       " << num_samples << std::endl;
+    *verbose_out << "Number of independent variables:   " << num_independent_variables << std::endl;
+    *verbose_out << "Mtry:                              " << mtry << std::endl;
+    *verbose_out << "Target node size:                  " << min_node_size << std::endl;
+    *verbose_out << "Variable importance mode:          " << importance_mode << std::endl;
+    *verbose_out << "Memory mode:                       " << memory_mode << std::endl;
+    *verbose_out << "Seed:                              " << seed << std::endl;
+    *verbose_out << "Number of threads:                 " << num_threads << std::endl;
+    *verbose_out << std::endl;
+  }
 
   if (prediction_mode) {
     writePredictionFile();
   } else {
-    *verbose_out << "Overall OOB prediction error:      " << overall_prediction_error << std::endl;
-    *verbose_out << std::endl;
+    if (verbose_out) {
+      *verbose_out << "Overall OOB prediction error:      " << overall_prediction_error << std::endl;
+      *verbose_out << std::endl;
+    }
 
     if (!split_select_weights.empty() & !split_select_weights[0].empty()) {
-      *verbose_out
-          << "Warning: Split select weights used. Variable importance measures are only comparable for variables with equal weights."
-          << std::endl;
+      if (verbose_out) {
+        *verbose_out
+            << "Warning: Split select weights used. Variable importance measures are only comparable for variables with equal weights."
+            << std::endl;
+      }
     }
 
     if (importance_mode != IMP_NONE) {
@@ -354,7 +359,7 @@ void Forest::writeImportanceFile() {
   }
 
   importance_file.close();
-  *verbose_out << "Saved variable importance to file " << filename << "." << std::endl;
+  if (verbose_out) *verbose_out << "Saved variable importance to file " << filename << "." << std::endl;
 }
 
 void Forest::saveToFile() {
@@ -385,7 +390,7 @@ void Forest::saveToFile() {
 
   // Close file
   outfile.close();
-  *verbose_out << "Saved forest to file " << filename << "." << std::endl;
+  if (verbose_out) *verbose_out << "Saved forest to file " << filename << "." << std::endl;
 }
 // #nocov end
 
@@ -767,7 +772,7 @@ void Forest::computeTreePermutationImportanceInThread(uint thread_idx, std::vect
 
 // #nocov start
 void Forest::loadFromFile(std::string filename) {
-  *verbose_out << "Loading forest from file " << filename << "." << std::endl;
+  if (verbose_out) *verbose_out << "Loading forest from file " << filename << "." << std::endl;
 
 // Open file for reading
   std::ifstream infile;
@@ -884,8 +889,10 @@ void Forest::showProgress(std::string operation, clock_t start_time, clock_t& la
     double relative_progress = (double) progress / (double) num_trees;
     double time_from_start = (clock() - start_time) / CLOCKS_PER_SEC;
     uint remaining_time = (1 / relative_progress - 1) * time_from_start;
-    *verbose_out << operation << " Progress: " << round(100 * relative_progress) << "%. Estimated remaining time: "
-    << beautifyTime(remaining_time) << "." << std::endl;
+    if (verbose_out) {
+      *verbose_out << operation << " Progress: " << round(100 * relative_progress)
+                   << "%. Estimated remaining time: " << beautifyTime(remaining_time) << "." << std::endl;
+    }
     lap_time = clock();
   }
 }
@@ -918,8 +925,10 @@ void Forest::showProgress(std::string operation, size_t max_progress) {
       double relative_progress = (double) progress / (double) max_progress;
       seconds time_from_start = duration_cast<seconds>(steady_clock::now() - start_time);
       uint remaining_time = (1 / relative_progress - 1) * time_from_start.count();
-      *verbose_out << operation << " Progress: " << round(100 * relative_progress) << "%. Estimated remaining time: "
-          << beautifyTime(remaining_time) << "." << std::endl;
+      if (verbose_out) {
+        *verbose_out << operation << " Progress: " << round(100 * relative_progress)
+                     << "%. Estimated remaining time: " << beautifyTime(remaining_time) << "." << std::endl;
+      }
       last_time = steady_clock::now();
     }
   }

--- a/src/ForestClassification.cpp
+++ b/src/ForestClassification.cpp
@@ -186,7 +186,9 @@ void ForestClassification::computePredictionErrorInternal() {
 
 // #nocov start
 void ForestClassification::writeOutputInternal() {
-  *verbose_out << "Tree type:                         " << "Classification" << std::endl;
+  if (verbose_out) {
+    *verbose_out << "Tree type:                         " << "Classification" << std::endl;
+  }
 }
 
 void ForestClassification::writeConfusionFile() {
@@ -229,7 +231,7 @@ void ForestClassification::writeConfusionFile() {
   }
 
   outfile.close();
-  *verbose_out << "Saved confusion matrix to file " << filename << "." << std::endl;
+  if (verbose_out) *verbose_out << "Saved confusion matrix to file " << filename << "." << std::endl;
 }
 
 void ForestClassification::writePredictionFile() {
@@ -264,7 +266,7 @@ void ForestClassification::writePredictionFile() {
     }
   }
 
-  *verbose_out << "Saved predictions to file " << filename << "." << std::endl;
+  if (verbose_out) *verbose_out << "Saved predictions to file " << filename << "." << std::endl;
 }
 
 void ForestClassification::saveToFileInternal(std::ofstream& outfile) {

--- a/src/ForestProbability.cpp
+++ b/src/ForestProbability.cpp
@@ -186,7 +186,9 @@ void ForestProbability::computePredictionErrorInternal() {
 
 // #nocov start
 void ForestProbability::writeOutputInternal() {
-  *verbose_out << "Tree type:                         " << "Probability estimation" << std::endl;
+  if (verbose_out) {
+    *verbose_out << "Tree type:                         " << "Probability estimation" << std::endl;
+  }
 }
 
 void ForestProbability::writeConfusionFile() {
@@ -203,7 +205,7 @@ void ForestProbability::writeConfusionFile() {
   outfile << "Overall OOB prediction error (MSE): " << overall_prediction_error << std::endl;
 
   outfile.close();
-  *verbose_out << "Saved prediction error to file " << filename << "." << std::endl;
+  if (verbose_out) *verbose_out << "Saved prediction error to file " << filename << "." << std::endl;
 }
 
 void ForestProbability::writePredictionFile() {
@@ -245,7 +247,7 @@ void ForestProbability::writePredictionFile() {
     }
   }
 
-  *verbose_out << "Saved predictions to file " << filename << "." << std::endl;
+  if (verbose_out) *verbose_out << "Saved predictions to file " << filename << "." << std::endl;
 }
 
 void ForestProbability::saveToFileInternal(std::ofstream& outfile) {

--- a/src/ForestRegression.cpp
+++ b/src/ForestRegression.cpp
@@ -138,7 +138,9 @@ void ForestRegression::computePredictionErrorInternal() {
 
 // #nocov start
 void ForestRegression::writeOutputInternal() {
-  *verbose_out << "Tree type:                         " << "Regression" << std::endl;
+  if (verbose_out) {
+    *verbose_out << "Tree type:                         " << "Regression" << std::endl;
+  }
 }
 
 void ForestRegression::writeConfusionFile() {
@@ -155,7 +157,7 @@ void ForestRegression::writeConfusionFile() {
   outfile << "Overall OOB prediction error (MSE): " << overall_prediction_error << std::endl;
 
   outfile.close();
-  *verbose_out << "Saved prediction error to file " << filename << "." << std::endl;
+  if (verbose_out) *verbose_out << "Saved prediction error to file " << filename << "." << std::endl;
 }
 
 void ForestRegression::writePredictionFile() {
@@ -190,7 +192,7 @@ void ForestRegression::writePredictionFile() {
     }
   }
 
-  *verbose_out << "Saved predictions to file " << filename << "." << std::endl;
+  if (verbose_out) *verbose_out << "Saved predictions to file " << filename << "." << std::endl;
 }
 
 void ForestRegression::saveToFileInternal(std::ofstream& outfile) {

--- a/src/ForestSurvival.cpp
+++ b/src/ForestSurvival.cpp
@@ -187,9 +187,11 @@ void ForestSurvival::computePredictionErrorInternal() {
 
 // #nocov start
 void ForestSurvival::writeOutputInternal() {
-  *verbose_out << "Tree type:                         " << "Survival" << std::endl;
-  *verbose_out << "Status variable name:              " << data->getVariableNames()[status_varID] << std::endl;
-  *verbose_out << "Status variable ID:                " << status_varID << std::endl;
+  if (verbose_out) {
+    *verbose_out << "Tree type:                         " << "Survival" << std::endl;
+    *verbose_out << "Status variable name:              " << data->getVariableNames()[status_varID] << std::endl;
+    *verbose_out << "Status variable ID:                " << status_varID << std::endl;
+  }
 }
 
 void ForestSurvival::writeConfusionFile() {
@@ -206,7 +208,7 @@ void ForestSurvival::writeConfusionFile() {
   outfile << "Overall OOB prediction error (1 - C): " << overall_prediction_error << std::endl;
 
   outfile.close();
-  *verbose_out << "Saved prediction error to file " << filename << "." << std::endl;
+  if (verbose_out) *verbose_out << "Saved prediction error to file " << filename << "." << std::endl;
 
 }
 
@@ -250,7 +252,7 @@ void ForestSurvival::writePredictionFile() {
     }
   }
 
-  *verbose_out << "Saved predictions to file " << filename << "." << std::endl;
+  if (verbose_out) *verbose_out << "Saved predictions to file " << filename << "." << std::endl;
 }
 
 void ForestSurvival::saveToFileInternal(std::ofstream& outfile) {

--- a/src/rangerCpp.cpp
+++ b/src/rangerCpp.cpp
@@ -174,9 +174,9 @@ Rcpp::List rangerCpp(uint treetype, std::string dependent_variable_name,
     forest->run(false);
     
     if (use_split_select_weights && importance_mode != IMP_NONE) {
-      *verbose_out
-          << "Warning: Split select weights used. Variable importance measures are only comparable for variables with equal weights."
-          << std::endl;
+      if (verbose_out) {
+        *verbose_out << "Warning: Split select weights used. Variable importance measures are only comparable for variables with equal weights." << std::endl;
+      }
     }
     
     // Use first non-empty dimension of predictions


### PR DESCRIPTION
When using ranger as a library, the caller may not want any output coming from ranger and therefore not initialise `verbose_out` (e.g. set to `nullptr`). However, this will currently cause segmentation faults when `verbose_out` is dereferenced. This commit guards all `verbose_out` dereferences to check the pointer is not `nullptr`.