### PR TITLE
Replace copy guard macro with deleted copy constructors

### DIFF
--- a/cpp_version/src/utility/ArgumentHandler.h
+++ b/cpp_version/src/utility/ArgumentHandler.h
@@ -36,6 +36,9 @@ public:
   ArgumentHandler(int argc, char **argv);
   virtual ~ArgumentHandler();
 
+  ArgumentHandler(const ArgumentHandler&)            = delete;
+  ArgumentHandler& operator=(const ArgumentHandler&) = delete;
+
   // Get arguments and catch conversion exceptions
   int processArguments();
 
@@ -83,8 +86,6 @@ private:
 
   int argc;
   char** argv;
-
-  DISALLOW_COPY_AND_ASSIGN(ArgumentHandler);
 };
 
 #endif /* ARGUMENTHANDLER_H_ */

--- a/src/Data.h
+++ b/src/Data.h
@@ -24,6 +24,9 @@ class Data {
 public:
   Data();
   virtual ~Data();
+  
+  Data(const Data&)            = delete;
+  Data& operator=(const Data&) = delete;
 
   virtual double get(size_t row, size_t col) const = 0;
 
@@ -194,9 +197,6 @@ protected:
 
   // Permuted samples for corrected impurity importance
   std::vector<size_t> permuted_sampleIDs;
-
-private:
-  DISALLOW_COPY_AND_ASSIGN(Data);
 };
 
 #endif /* DATA_H_ */

--- a/src/DataChar.h
+++ b/src/DataChar.h
@@ -26,6 +26,9 @@ public:
   DataChar(double* data_double, std::vector<std::string> variable_names, size_t num_rows, size_t num_cols, bool& error);
   virtual ~DataChar();
 
+  DataChar(const DataChar&)            = delete;
+  DataChar& operator=(const DataChar&) = delete;
+
   double get(size_t row, size_t col) const {
     // Use permuted data for corrected impurity importance
     if (col >= num_cols) {
@@ -58,8 +61,6 @@ public:
 
 private:
   char* data;
-
-  DISALLOW_COPY_AND_ASSIGN(DataChar);
 };
 
 #endif /* DATACHAR_H_ */

--- a/src/DataDouble.h
+++ b/src/DataDouble.h
@@ -27,6 +27,9 @@ public:
     this->num_cols_no_snp = num_cols;
   }
   virtual ~DataDouble();
+  
+  DataDouble(const DataDouble&)            = delete;
+  DataDouble& operator=(const DataDouble&) = delete;
 
   double get(size_t row, size_t col) const {
     // Use permuted data for corrected impurity importance
@@ -55,8 +58,6 @@ public:
 
 private:
   double* data;
-
-  DISALLOW_COPY_AND_ASSIGN(DataDouble);
 };
 
 #endif /* DATADOUBLE_H_ */

--- a/src/DataFloat.h
+++ b/src/DataFloat.h
@@ -24,6 +24,9 @@ public:
   DataFloat(double* data_double, std::vector<std::string> variable_names, size_t num_rows, size_t num_cols);
   virtual ~DataFloat();
 
+  DataFloat(const DataFloat&)            = delete;
+  DataFloat& operator=(const DataFloat&) = delete;
+
   double get(size_t row, size_t col) const {
     // Use permuted data for corrected impurity importance
     if (col >= num_cols) {
@@ -50,8 +53,6 @@ public:
 
 private:
   float* data;
-
-  DISALLOW_COPY_AND_ASSIGN(DataFloat);
 };
 
 #endif /* DATAFLOAT_H_ */

--- a/src/DataSparse.h
+++ b/src/DataSparse.h
@@ -45,6 +45,9 @@ public:
     this->num_cols_no_snp = num_cols;
   }
   virtual ~DataSparse();
+  
+  DataSparse(const DataSparse&)            = delete;
+  DataSparse& operator=(const DataSparse&) = delete;
 
   double get(size_t row, size_t col) const {
     return data->coeff(row, col);
@@ -60,8 +63,6 @@ public:
 
 private:
   Eigen::SparseMatrix<double>* data;
-
-  DISALLOW_COPY_AND_ASSIGN(DataSparse);
 };
 
 #endif /* DATASPARSE_H_ */

--- a/src/Forest.h
+++ b/src/Forest.h
@@ -32,6 +32,9 @@ public:
   Forest();
   virtual ~Forest();
 
+  Forest(const Forest&)            = delete;
+  Forest& operator=(const Forest&) = delete;
+
   // Init from c++ main or Rcpp from R
   void initCpp(std::string dependent_variable_name, MemoryMode memory_mode, std::string input_file, uint mtry,
       std::string output_prefix, uint num_trees, std::ostream* verbose_out, uint seed, uint num_threads,
@@ -229,9 +232,6 @@ protected:
   size_t aborted_threads;
   bool aborted;
 #endif
-
-private:
-  DISALLOW_COPY_AND_ASSIGN(Forest);
 };
 
 #endif /* FOREST_H_ */

--- a/src/ForestClassification.h
+++ b/src/ForestClassification.h
@@ -25,6 +25,9 @@ public:
   ForestClassification();
   virtual ~ForestClassification();
 
+  ForestClassification(const ForestClassification&)            = delete;
+  ForestClassification& operator=(const ForestClassification&) = delete;
+
   void loadForest(size_t dependent_varID, size_t num_trees,
       std::vector<std::vector<std::vector<size_t>> >& forest_child_nodeIDs,
       std::vector<std::vector<size_t>>& forest_split_varIDs, std::vector<std::vector<double>>& forest_split_values,
@@ -60,9 +63,6 @@ protected:
 
   // Table with classifications and true classes
   std::map<std::pair<double, double>, size_t> classification_table;
-
-private:
-  DISALLOW_COPY_AND_ASSIGN(ForestClassification);
 };
 
 #endif /* FORESTCLASSIFICATION_H_ */

--- a/src/ForestProbability.h
+++ b/src/ForestProbability.h
@@ -25,6 +25,9 @@ public:
   ForestProbability();
   virtual ~ForestProbability();
 
+  ForestProbability(const ForestProbability&)            = delete;
+  ForestProbability& operator=(const ForestProbability&) = delete;
+
   void loadForest(size_t dependent_varID, size_t num_trees,
       std::vector<std::vector<std::vector<size_t>> >& forest_child_nodeIDs,
       std::vector<std::vector<size_t>>& forest_split_varIDs, std::vector<std::vector<double>>& forest_split_values,
@@ -71,9 +74,6 @@ protected:
 
   // Table with classifications and true classes
   std::map<std::pair<double, double>, size_t> classification_table;
-
-private:
-  DISALLOW_COPY_AND_ASSIGN(ForestProbability);
 };
 
 #endif /* FORESTPROBABILITY_H_ */

--- a/src/ForestRegression.h
+++ b/src/ForestRegression.h
@@ -22,6 +22,9 @@ class ForestRegression: public Forest {
 public:
   ForestRegression();
   virtual ~ForestRegression();
+  
+  ForestRegression(const ForestRegression&)            = delete;
+  ForestRegression& operator=(const ForestRegression&) = delete;
 
   void loadForest(size_t dependent_varID, size_t num_trees,
       std::vector<std::vector<std::vector<size_t>> >& forest_child_nodeIDs,
@@ -39,8 +42,6 @@ private:
   void writePredictionFile();
   void saveToFileInternal(std::ofstream& outfile);
   void loadFromFileInternal(std::ifstream& infile);
-
-  DISALLOW_COPY_AND_ASSIGN(ForestRegression);
 };
 
 #endif /* FORESTREGRESSION_H_ */

--- a/src/ForestSurvival.h
+++ b/src/ForestSurvival.h
@@ -23,6 +23,9 @@ class ForestSurvival: public Forest {
 public:
   ForestSurvival();
   virtual ~ForestSurvival();
+  
+  ForestSurvival(const ForestSurvival&)            = delete;
+  ForestSurvival& operator=(const ForestSurvival&) = delete;
 
   void loadForest(size_t dependent_varID, size_t num_trees,
       std::vector<std::vector<std::vector<size_t>> >& forest_child_nodeIDs,
@@ -61,8 +64,6 @@ private:
   size_t status_varID;
   std::vector<double> unique_timepoints;
   std::vector<size_t> response_timepointIDs;
-
-  DISALLOW_COPY_AND_ASSIGN(ForestSurvival);
 };
 
 #endif /* FORESTSURVIVAL_H_ */

--- a/src/Tree.h
+++ b/src/Tree.h
@@ -29,6 +29,9 @@ public:
       std::vector<double>& split_values);
 
   virtual ~Tree();
+  
+  Tree(const Tree&)            = delete;
+  Tree& operator=(const Tree&) = delete;
 
   void init(Data* data, uint mtry, size_t dependent_varID, size_t num_samples, uint seed,
       std::vector<size_t>* deterministic_varIDs, std::vector<size_t>* split_select_varIDs,
@@ -160,9 +163,6 @@ protected:
   double alpha;
   double minprop;
   uint num_random_splits;
-
-private:
-  DISALLOW_COPY_AND_ASSIGN(Tree);
 };
 
 #endif /* TREE_H_ */

--- a/src/TreeClassification.h
+++ b/src/TreeClassification.h
@@ -26,6 +26,9 @@ public:
 
   virtual ~TreeClassification();
 
+  TreeClassification(const TreeClassification&)            = delete;
+  TreeClassification& operator=(const TreeClassification&) = delete;
+
   void allocateMemory();
 
   double estimate(size_t nodeID);
@@ -86,8 +89,6 @@ private:
 
   size_t* counter;
   size_t* counter_per_class;
-
-  DISALLOW_COPY_AND_ASSIGN(TreeClassification);
 };
 
 #endif /* TREECLASSIFICATION_H_ */

--- a/src/TreeProbability.h
+++ b/src/TreeProbability.h
@@ -28,6 +28,9 @@ public:
       std::vector<std::vector<double>>& terminal_class_counts);
 
   virtual ~TreeProbability();
+  
+  TreeProbability(const TreeProbability&)            = delete;
+  TreeProbability& operator=(const TreeProbability&) = delete;
 
   void allocateMemory();
 
@@ -96,8 +99,6 @@ private:
 
   size_t* counter;
   size_t* counter_per_class;
-
-  DISALLOW_COPY_AND_ASSIGN(TreeProbability);
 };
 
 #endif /* TREEPROBABILITY_H_ */

--- a/src/TreeRegression.h
+++ b/src/TreeRegression.h
@@ -24,6 +24,9 @@ public:
       std::vector<double>& split_values);
 
   virtual ~TreeRegression();
+  
+  TreeRegression(const TreeRegression&)            = delete;
+  TreeRegression& operator=(const TreeRegression&) = delete;
 
   void allocateMemory();
 
@@ -78,8 +81,6 @@ private:
 
   size_t* counter;
   double* sums;
-
-  DISALLOW_COPY_AND_ASSIGN(TreeRegression);
 };
 
 #endif /* TREEREGRESSION_H_ */

--- a/src/TreeSurvival.h
+++ b/src/TreeSurvival.h
@@ -26,6 +26,9 @@ public:
 
   virtual ~TreeSurvival();
 
+  TreeSurvival(const TreeSurvival&)            = delete;
+  TreeSurvival& operator=(const TreeSurvival&) = delete;
+
   void allocateMemory();
 
   void appendToFileInternal(std::ofstream& file);
@@ -100,8 +103,6 @@ private:
   // Fields to save to while tree growing
   size_t* num_deaths;
   size_t* num_samples_at_risk;
-
-  DISALLOW_COPY_AND_ASSIGN(TreeSurvival);
 };
 
 #endif /* TREESURVIVAL_H_ */

--- a/src/globals.h
+++ b/src/globals.h
@@ -12,10 +12,6 @@ R package "ranger" under GPL3 license.
 #ifndef GLOBALS_H_
 #define GLOBALS_H_
 
-#define DISALLOW_COPY_AND_ASSIGN(TypeName) \
-    TypeName(const TypeName&);             \
-    void operator=(const TypeName&)
-
 // Pi
 #ifndef M_PI
 #define M_PI 3.14159265358979323846


### PR DESCRIPTION
In C++11, the prefered way to disallow copy construction is to explicetly delete both public copy constructors. This commit replaces all instances of `DISALLOW_COPY_AND_ASSIGN` with explicit copy constructor `delete`tion.