### PR TITLE
Add override tags to overriding functions

### DIFF
--- a/src/DataChar.h
+++ b/src/DataChar.h
@@ -24,9 +24,9 @@ class DataChar: public Data {
 public:
   DataChar();
   DataChar(double* data_double, std::vector<std::string> variable_names, size_t num_rows, size_t num_cols, bool& error);
-  virtual ~DataChar();
+  virtual ~DataChar() override;
 
-  double get(size_t row, size_t col) const {
+  double get(size_t row, size_t col) const override {
     // Use permuted data for corrected impurity importance
     if (col >= num_cols) {
       col = getUnpermutedVarID(col);
@@ -42,11 +42,11 @@ public:
     }
   }
 
-  void reserveMemory() {
+  void reserveMemory() override {
     data = new char[num_cols * num_rows];
   }
 
-  void set(size_t col, size_t row, double value, bool& error) {
+  void set(size_t col, size_t row, double value, bool& error) override {
     if (value > CHAR_MAX || value < CHAR_MIN) {
       error = true;
     }

--- a/src/DataDouble.h
+++ b/src/DataDouble.h
@@ -26,9 +26,9 @@ public:
     this->num_cols = num_cols;
     this->num_cols_no_snp = num_cols;
   }
-  virtual ~DataDouble();
+  virtual ~DataDouble() override;
 
-  double get(size_t row, size_t col) const {
+  double get(size_t row, size_t col) const override {
     // Use permuted data for corrected impurity importance
     if (col >= num_cols) {
       col = getUnpermutedVarID(col);
@@ -45,11 +45,11 @@ public:
     }
   }
 
-  void reserveMemory() {
+  void reserveMemory() override {
     data = new double[num_cols * num_rows];
   }
 
-  void set(size_t col, size_t row, double value, bool& error) {
+  void set(size_t col, size_t row, double value, bool& error) override {
     data[col * num_rows + row] = value;
   }
 

--- a/src/DataFloat.h
+++ b/src/DataFloat.h
@@ -22,9 +22,9 @@ class DataFloat: public Data {
 public:
   DataFloat();
   DataFloat(double* data_double, std::vector<std::string> variable_names, size_t num_rows, size_t num_cols);
-  virtual ~DataFloat();
+  virtual ~DataFloat() override;
 
-  double get(size_t row, size_t col) const {
+  double get(size_t row, size_t col) const override {
     // Use permuted data for corrected impurity importance
     if (col >= num_cols) {
       col = getUnpermutedVarID(col);
@@ -40,11 +40,11 @@ public:
     }
   }
 
-  void reserveMemory() {
+  void reserveMemory() override {
     data = new float[num_cols * num_rows];
   }
 
-  void set(size_t col, size_t row, double value, bool& error) {
+  void set(size_t col, size_t row, double value, bool& error) override {
     data[col * num_rows + row] = (float) value;
   }
 

--- a/src/DataSparse.h
+++ b/src/DataSparse.h
@@ -44,17 +44,17 @@ public:
     this->num_cols = num_cols;
     this->num_cols_no_snp = num_cols;
   }
-  virtual ~DataSparse();
+  virtual ~DataSparse() override;
 
-  double get(size_t row, size_t col) const {
+  double get(size_t row, size_t col) const override {
     return data->coeff(row, col);
   }
 
-  void reserveMemory() {
+  void reserveMemory() override {
     data = new Eigen::SparseMatrix<double>(num_rows, num_cols);
   }
 
-  void set(size_t col, size_t row, double value, bool& error) {
+  void set(size_t col, size_t row, double value, bool& error) override {
     data->coeffRef(row, col) = value;
   }
 

--- a/src/ForestClassification.h
+++ b/src/ForestClassification.h
@@ -23,7 +23,7 @@ R package "ranger" under GPL3 license.
 class ForestClassification: public Forest {
 public:
   ForestClassification();
-  virtual ~ForestClassification();
+  virtual ~ForestClassification() override;
 
   void loadForest(size_t dependent_varID, size_t num_trees,
       std::vector<std::vector<std::vector<size_t>> >& forest_child_nodeIDs,
@@ -39,16 +39,16 @@ public:
   }
 
 protected:
-  void initInternal(std::string status_variable_name);
-  void growInternal();
-  void allocatePredictMemory();
-  void predictInternal(size_t sample_idx);
-  void computePredictionErrorInternal();
-  void writeOutputInternal();
-  void writeConfusionFile();
-  void writePredictionFile();
-  void saveToFileInternal(std::ofstream& outfile);
-  void loadFromFileInternal(std::ifstream& infile);
+  void initInternal(std::string status_variable_name) override;
+  void growInternal() override;
+  void allocatePredictMemory() override;
+  void predictInternal(size_t sample_idx) override;
+  void computePredictionErrorInternal() override;
+  void writeOutputInternal() override;
+  void writeConfusionFile() override;
+  void writePredictionFile() override;
+  void saveToFileInternal(std::ofstream& outfile) override;
+  void loadFromFileInternal(std::ifstream& infile) override;
 
   // Classes of the dependent variable and classIDs for responses
   std::vector<double> class_values;

--- a/src/ForestProbability.h
+++ b/src/ForestProbability.h
@@ -23,7 +23,7 @@ R package "ranger" under GPL3 license.
 class ForestProbability: public Forest {
 public:
   ForestProbability();
-  virtual ~ForestProbability();
+  virtual ~ForestProbability() override;
 
   void loadForest(size_t dependent_varID, size_t num_trees,
       std::vector<std::vector<std::vector<size_t>> >& forest_child_nodeIDs,
@@ -50,16 +50,16 @@ public:
   }
 
 protected:
-  void initInternal(std::string status_variable_name);
-  void growInternal();
-  void allocatePredictMemory();
-  void predictInternal(size_t sample_idx);
-  void computePredictionErrorInternal();
-  void writeOutputInternal();
-  void writeConfusionFile();
-  void writePredictionFile();
-  void saveToFileInternal(std::ofstream& outfile);
-  void loadFromFileInternal(std::ifstream& infile);
+  void initInternal(std::string status_variable_name) override;
+  void growInternal() override;
+  void allocatePredictMemory() override;
+  void predictInternal(size_t sample_idx) override;
+  void computePredictionErrorInternal() override;
+  void writeOutputInternal() override;
+  void writeConfusionFile() override;
+  void writePredictionFile() override;
+  void saveToFileInternal(std::ofstream& outfile) override;
+  void loadFromFileInternal(std::ifstream& infile) override;
 
   // Classes of the dependent variable and classIDs for responses
   std::vector<double> class_values;

--- a/src/ForestRegression.h
+++ b/src/ForestRegression.h
@@ -21,7 +21,7 @@ R package "ranger" under GPL3 license.
 class ForestRegression: public Forest {
 public:
   ForestRegression();
-  virtual ~ForestRegression();
+  virtual ~ForestRegression() override;
 
   void loadForest(size_t dependent_varID, size_t num_trees,
       std::vector<std::vector<std::vector<size_t>> >& forest_child_nodeIDs,
@@ -29,16 +29,16 @@ public:
       std::vector<bool>& is_ordered_variable);
 
 private:
-  void initInternal(std::string status_variable_name);
-  void growInternal();
-  void allocatePredictMemory();
-  void predictInternal(size_t sample_idx);
-  void computePredictionErrorInternal();
-  void writeOutputInternal();
-  void writeConfusionFile();
-  void writePredictionFile();
-  void saveToFileInternal(std::ofstream& outfile);
-  void loadFromFileInternal(std::ifstream& infile);
+  void initInternal(std::string status_variable_name) override;
+  void growInternal() override;
+  void allocatePredictMemory() override;
+  void predictInternal(size_t sample_idx) override;
+  void computePredictionErrorInternal() override;
+  void writeOutputInternal() override;
+  void writeConfusionFile() override;
+  void writePredictionFile() override;
+  void saveToFileInternal(std::ofstream& outfile) override;
+  void loadFromFileInternal(std::ifstream& infile) override;
 
   DISALLOW_COPY_AND_ASSIGN(ForestRegression);
 };

--- a/src/ForestSurvival.h
+++ b/src/ForestSurvival.h
@@ -22,7 +22,7 @@ R package "ranger" under GPL3 license.
 class ForestSurvival: public Forest {
 public:
   ForestSurvival();
-  virtual ~ForestSurvival();
+  virtual ~ForestSurvival() override;
 
   void loadForest(size_t dependent_varID, size_t num_trees,
       std::vector<std::vector<std::vector<size_t>> >& forest_child_nodeIDs,
@@ -47,16 +47,16 @@ public:
   }
 
 private:
-  void initInternal(std::string status_variable_name);
-  void growInternal();
-  void allocatePredictMemory();
-  void predictInternal(size_t sample_idx);
-  void computePredictionErrorInternal();
-  void writeOutputInternal();
-  void writeConfusionFile();
-  void writePredictionFile();
-  void saveToFileInternal(std::ofstream& outfile);
-  void loadFromFileInternal(std::ifstream& infile);
+  void initInternal(std::string status_variable_name) override;
+  void growInternal() override;
+  void allocatePredictMemory() override;
+  void predictInternal(size_t sample_idx) override;
+  void computePredictionErrorInternal() override;
+  void writeOutputInternal() override;
+  void writeConfusionFile() override;
+  void writePredictionFile() override;
+  void saveToFileInternal(std::ofstream& outfile) override;
+  void loadFromFileInternal(std::ifstream& infile) override;
 
   size_t status_varID;
   std::vector<double> unique_timepoints;

--- a/src/TreeClassification.h
+++ b/src/TreeClassification.h
@@ -24,13 +24,13 @@ public:
   TreeClassification(std::vector<std::vector<size_t>>& child_nodeIDs, std::vector<size_t>& split_varIDs,
       std::vector<double>& split_values, std::vector<double>* class_values, std::vector<uint>* response_classIDs);
 
-  virtual ~TreeClassification();
+  virtual ~TreeClassification() override;
 
-  void allocateMemory();
+  void allocateMemory() override;
 
   double estimate(size_t nodeID);
   void computePermutationImportanceInternal(std::vector<std::vector<size_t>>* permutations);
-  void appendToFileInternal(std::ofstream& file);
+  void appendToFileInternal(std::ofstream& file) override;
 
   double getPrediction(size_t sampleID) const {
     size_t terminal_nodeID = prediction_terminal_nodeIDs[sampleID];
@@ -42,10 +42,10 @@ public:
   }
 
 private:
-  bool splitNodeInternal(size_t nodeID, std::vector<size_t>& possible_split_varIDs);
-  void createEmptyNodeInternal();
+  bool splitNodeInternal(size_t nodeID, std::vector<size_t>& possible_split_varIDs) override;
+  void createEmptyNodeInternal() override;
 
-  double computePredictionAccuracyInternal();
+  double computePredictionAccuracyInternal() override;
 
   // Called by splitNodeInternal(). Sets split_varIDs and split_values.
   bool findBestSplit(size_t nodeID, std::vector<size_t>& possible_split_varIDs);
@@ -64,10 +64,10 @@ private:
 
   void addGiniImportance(size_t nodeID, size_t varID, double decrease);
 
-  void bootstrapClassWise();
-  void bootstrapWithoutReplacementClassWise();
+  void bootstrapClassWise() override;
+  void bootstrapWithoutReplacementClassWise() override;
 
-  void cleanUpInternal() {
+  void cleanUpInternal() override {
     if (counter != 0) {
       delete[] counter;
     }

--- a/src/TreeProbability.h
+++ b/src/TreeProbability.h
@@ -27,13 +27,13 @@ public:
       std::vector<double>& split_values, std::vector<double>* class_values, std::vector<uint>* response_classIDs,
       std::vector<std::vector<double>>& terminal_class_counts);
 
-  virtual ~TreeProbability();
+  virtual ~TreeProbability() override;
 
-  void allocateMemory();
+  void allocateMemory() override;
 
   void addToTerminalNodes(size_t nodeID);
   void computePermutationImportanceInternal(std::vector<std::vector<size_t>>* permutations);
-  void appendToFileInternal(std::ofstream& file);
+  void appendToFileInternal(std::ofstream& file) override;
 
   const std::vector<double>& getPrediction(size_t sampleID) const {
     size_t terminal_nodeID = prediction_terminal_nodeIDs[sampleID];
@@ -49,10 +49,10 @@ public:
   }
 
 private:
-  bool splitNodeInternal(size_t nodeID, std::vector<size_t>& possible_split_varIDs);
-  void createEmptyNodeInternal();
+  bool splitNodeInternal(size_t nodeID, std::vector<size_t>& possible_split_varIDs) override;
+  void createEmptyNodeInternal() override;
 
-  double computePredictionAccuracyInternal();
+  double computePredictionAccuracyInternal() override;
 
   // Called by splitNodeInternal(). Sets split_varIDs and split_values.
   bool findBestSplit(size_t nodeID, std::vector<size_t>& possible_split_varIDs);
@@ -71,10 +71,10 @@ private:
 
   void addImpurityImportance(size_t nodeID, size_t varID, double decrease);
 
-  void bootstrapClassWise();
-  void bootstrapWithoutReplacementClassWise();
+  void bootstrapClassWise() override;
+  void bootstrapWithoutReplacementClassWise() override;
 
-  void cleanUpInternal() {
+  void cleanUpInternal() override {
     if (counter != 0) {
       delete[] counter;
     }

--- a/src/TreeRegression.h
+++ b/src/TreeRegression.h
@@ -23,13 +23,13 @@ public:
   TreeRegression(std::vector<std::vector<size_t>>& child_nodeIDs, std::vector<size_t>& split_varIDs,
       std::vector<double>& split_values);
 
-  virtual ~TreeRegression();
+  virtual ~TreeRegression() override;
 
-  void allocateMemory();
+  void allocateMemory() override;
 
   double estimate(size_t nodeID);
   void computePermutationImportanceInternal(std::vector<std::vector<size_t>>* permutations);
-  void appendToFileInternal(std::ofstream& file);
+  void appendToFileInternal(std::ofstream& file) override;
 
   double getPrediction(size_t sampleID) const {
     size_t terminal_nodeID = prediction_terminal_nodeIDs[sampleID];
@@ -41,10 +41,10 @@ public:
   }
 
 private:
-  bool splitNodeInternal(size_t nodeID, std::vector<size_t>& possible_split_varIDs);
-  void createEmptyNodeInternal();
+  bool splitNodeInternal(size_t nodeID, std::vector<size_t>& possible_split_varIDs) override;
+  void createEmptyNodeInternal() override;
 
-  double computePredictionAccuracyInternal();
+  double computePredictionAccuracyInternal() override;
 
   // Called by splitNodeInternal(). Sets split_varIDs and split_values.
   bool findBestSplit(size_t nodeID, std::vector<size_t>& possible_split_varIDs);
@@ -67,7 +67,7 @@ private:
 
   double computePredictionMSE();
 
-  void cleanUpInternal() {
+  void cleanUpInternal() override {
     if (counter != 0) {
       delete[] counter;
     }

--- a/src/TreeSurvival.h
+++ b/src/TreeSurvival.h
@@ -24,11 +24,11 @@ public:
       std::vector<double>& split_values, std::vector<std::vector<double>> chf, std::vector<double>* unique_timepoints,
       std::vector<size_t>* response_timepointIDs);
 
-  virtual ~TreeSurvival();
+  virtual ~TreeSurvival() override;
 
-  void allocateMemory();
+  void allocateMemory() override;
 
-  void appendToFileInternal(std::ofstream& file);
+  void appendToFileInternal(std::ofstream& file) override;
   void computePermutationImportanceInternal(std::vector<std::vector<size_t>>* permutations);
 
   const std::vector<std::vector<double> >& getChf() const {
@@ -46,11 +46,11 @@ public:
 
 private:
 
-  void createEmptyNodeInternal();
+  void createEmptyNodeInternal() override;
   void computeSurvival(size_t nodeID);
-  double computePredictionAccuracyInternal();
+  double computePredictionAccuracyInternal() override;
 
-  bool splitNodeInternal(size_t nodeID, std::vector<size_t>& possible_split_varIDs);
+  bool splitNodeInternal(size_t nodeID, std::vector<size_t>& possible_split_varIDs) override;
 
   bool findBestSplit(size_t nodeID, std::vector<size_t>& possible_split_varIDs);
   bool findBestSplitMaxstat(size_t nodeID, std::vector<size_t>& possible_split_varIDs);
@@ -82,7 +82,7 @@ private:
 
   void addImpurityImportance(size_t nodeID, size_t varID, double decrease);
 
-  void cleanUpInternal() {
+  void cleanUpInternal() override {
     delete[] num_deaths;
     delete[] num_samples_at_risk;
   }


### PR DESCRIPTION
It is good practice to mark overriding functions with the `override` specifier. This commit marks all such methods with `override`.