### PR TITLE
changed ranger --help to ./ranger --help in c++ usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ ranger(Species ~ ., data = iris)
 In the C++ version type 
 
 ```bash
-ranger --help 
+./ranger --help 
 ```
 
 for a list of commands. First you need a training dataset in a file. This file should contain one header line with variable names and one line with variable values per sample (numeric only). Variable names must not contain any whitespace, comma or semicolon. Values can be seperated by whitespace, comma or semicolon but can not be mixed in one file. A typical call of ranger would be for example


### PR DESCRIPTION
In trying the example `ranger --help` I realized that I needed to prefix this with dot-slash (i.e. `./ranger --help`) for the command to work.