### PR TITLE
Catch rinfJack calibration errors

### DIFF
--- a/R/infinitesimalJackknife.R
+++ b/R/infinitesimalJackknife.R
@@ -98,16 +98,18 @@ rInfJack = function(pred, inbag, calibrate = TRUE, used.trees = NULL) {
     sigma2 = (delta^2 + (1 - delta)^2) / (2 * (1 - delta)^2) * sigma2.ss
     
     # Use Monte Carlo noise scale estimate for empirical Bayes calibration
-    vars.calibrated = tryCatch(
+    results = tryCatch(
       expr = {
-        calibrateEB(vars, sigma2)
+        vars.calibrated = calibrateEB(vars, sigma2)
+        results$var.hat = vars.calibrated
+        results
       }, 
       error = function(e) {
-        warning("Calibration failed. Falling back to non-calibrated variance estimates.")
-        rInfJack(pred, inbag, calibrate = FALSE, used.trees = used.trees)
+        warning(sprintf("Calibration failed with error:\n%sFalling back to non-calibrated variance estimates.", e))
+        results = rInfJack(pred, inbag, calibrate = FALSE, used.trees = used.trees)
+        return(results)
       }
     )
-    results$var.hat = vars.calibrated
   }
   
   return(results)

--- a/R/infinitesimalJackknife.R
+++ b/R/infinitesimalJackknife.R
@@ -98,7 +98,15 @@ rInfJack = function(pred, inbag, calibrate = TRUE, used.trees = NULL) {
     sigma2 = (delta^2 + (1 - delta)^2) / (2 * (1 - delta)^2) * sigma2.ss
     
     # Use Monte Carlo noise scale estimate for empirical Bayes calibration
-    vars.calibrated = calibrateEB(vars, sigma2)
+    vars.calibrated = tryCatch(
+      expr = {
+        calibrateEB(vars, sigma2)
+      }, 
+      error = function(e) {
+        warning("Calibration failed. Falling back to non-calibrated variance estimates.")
+        rInfJack(pred, inbag, calibrate = FALSE, used.trees = used.trees)
+      }
+    )
     results$var.hat = vars.calibrated
   }
   


### PR DESCRIPTION
nlm in calibrateEB can fail due to non-finite values of the log-likelihood to be optimized.
Unfortunately, I'm lacking an example as this behaviour was experienced during two mlrMBO-based tuning benchmarks with no state saving. However, falling back to non-calibrated variances should always work.