### PR TITLE
Remove split_select_varIDs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: ranger
 Type: Package
 Title: A Fast Implementation of Random Forests
-Version: 0.12.1
-Date: 2020-01-10
+Version: 0.12.2
+Date: 2020-01-19
 Author: Marvin N. Wright [aut, cre], Stefan Wager [ctb], Philipp Probst [ctb]
 Maintainer: Marvin N. Wright <cran@wrig.de>
 Description: A fast implementation of Random Forests, particularly suited for high

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,10 @@
 
+##### Version 0.12.2
+* Bug fixes
+
+##### Version 0.12.1
+* Bug fixes
+
 ##### Version 0.12.0
 * Faster computation (in some cases)
 * Add local variable importance 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
 
+##### Version 0.12.2
+* Bug fixes
+
 ##### Version 0.12.1
 * Bug fixes
 

--- a/cpp_version/src/version.h
+++ b/cpp_version/src/version.h
@@ -1,3 +1,3 @@
 #ifndef RANGER_VERSION
-#define RANGER_VERSION "0.12.1"
+#define RANGER_VERSION "0.12.2"
 #endif

--- a/src/Forest.cpp
+++ b/src/Forest.cpp
@@ -475,7 +475,7 @@ void Forest::grow() {
       tree_manual_inbag = &manual_inbag[0];
     }
 
-    trees[i]->init(data.get(), mtry, num_samples, tree_seed, &deterministic_varIDs, &split_select_varIDs,
+    trees[i]->init(data.get(), mtry, num_samples, tree_seed, &deterministic_varIDs,
         tree_split_select_weights, importance_mode, min_node_size, sample_with_replacement, memory_saving_splitting,
         splitrule, &case_weights, tree_manual_inbag, keep_inbag, &sample_fraction, alpha, minprop, holdout,
         num_random_splits, max_depth, &regularization_factor, regularization_usedepth, &split_varIDs_used);
@@ -965,7 +965,6 @@ void Forest::setSplitWeightVector(std::vector<std::vector<double>>& split_select
     this->split_select_weights.clear();
     this->split_select_weights.resize(num_trees, std::vector<double>(num_weights));
   }
-  this->split_select_varIDs.resize(num_weights);
   deterministic_varIDs.reserve(num_weights);
 
   // Split up in deterministic and weighted variables, ignore zero weights
@@ -984,7 +983,6 @@ void Forest::setSplitWeightVector(std::vector<std::vector<double>>& split_select
         if (weight == 1) {
           deterministic_varIDs.push_back(j);
         } else if (weight < 1 && weight > 0) {
-          this->split_select_varIDs[j] = j;
           this->split_select_weights[i][j] = weight;
         } else if (weight == 0) {
           ++num_zero_weights;
@@ -1005,10 +1003,6 @@ void Forest::setSplitWeightVector(std::vector<std::vector<double>>& split_select
     if (importance_mode == IMP_GINI_CORRECTED) {
       std::vector<double>* sw = &(this->split_select_weights[i]);
       std::copy_n(sw->begin(), num_independent_variables, sw->begin() + num_independent_variables);
-
-      for (size_t k = 0; k < num_independent_variables; ++k) {
-        split_select_varIDs[num_independent_variables + k] = num_independent_variables + k;
-      }
 
       size_t num_deterministic_varIDs = deterministic_varIDs.size();
       for (size_t k = 0; k < num_deterministic_varIDs; ++k) {

--- a/src/Forest.h
+++ b/src/Forest.h
@@ -226,7 +226,6 @@ protected:
   // Weight vector for selecting possible split variables, one weight between 0 (never select) and 1 (always select) for each variable
   // Deterministic variables are always selected
   std::vector<size_t> deterministic_varIDs;
-  std::vector<size_t> split_select_varIDs;
   std::vector<std::vector<double>> split_select_weights;
 
   // Bootstrap weights

--- a/src/Tree.cpp
+++ b/src/Tree.cpp
@@ -17,8 +17,8 @@
 namespace ranger {
 
 Tree::Tree() :
-    mtry(0), num_samples(0), num_samples_oob(0), min_node_size(0), deterministic_varIDs(0), split_select_varIDs(0), split_select_weights(
-        0), case_weights(0), manual_inbag(0), oob_sampleIDs(0), holdout(false), keep_inbag(false), data(0), regularization_factor(0), regularization_usedepth(
+    mtry(0), num_samples(0), num_samples_oob(0), min_node_size(0), deterministic_varIDs(0), split_select_weights(0), case_weights(
+        0), manual_inbag(0), oob_sampleIDs(0), holdout(false), keep_inbag(false), data(0), regularization_factor(0), regularization_usedepth(
         false), split_varIDs_used(0), variable_importance(0), importance_mode(DEFAULT_IMPORTANCE_MODE), sample_with_replacement(
         true), sample_fraction(0), memory_saving_splitting(false), splitrule(DEFAULT_SPLITRULE), alpha(DEFAULT_ALPHA), minprop(
         DEFAULT_MINPROP), num_random_splits(DEFAULT_NUM_RANDOM_SPLITS), max_depth(DEFAULT_MAXDEPTH), depth(0), last_left_nodeID(
@@ -27,22 +27,21 @@ Tree::Tree() :
 
 Tree::Tree(std::vector<std::vector<size_t>>& child_nodeIDs, std::vector<size_t>& split_varIDs,
     std::vector<double>& split_values) :
-    mtry(0), num_samples(0), num_samples_oob(0), min_node_size(0), deterministic_varIDs(0), split_select_varIDs(0), split_select_weights(
-        0), case_weights(0), manual_inbag(0), split_varIDs(split_varIDs), split_values(split_values), child_nodeIDs(
-        child_nodeIDs), oob_sampleIDs(0), holdout(false), keep_inbag(false), data(0), regularization_factor(0), regularization_usedepth(false), split_varIDs_used(
+    mtry(0), num_samples(0), num_samples_oob(0), min_node_size(0), deterministic_varIDs(0), split_select_weights(0), case_weights(
+        0), manual_inbag(0), split_varIDs(split_varIDs), split_values(split_values), child_nodeIDs(child_nodeIDs), oob_sampleIDs(
+        0), holdout(false), keep_inbag(false), data(0), regularization_factor(0), regularization_usedepth(false), split_varIDs_used(
         0), variable_importance(0), importance_mode(DEFAULT_IMPORTANCE_MODE), sample_with_replacement(true), sample_fraction(
         0), memory_saving_splitting(false), splitrule(DEFAULT_SPLITRULE), alpha(DEFAULT_ALPHA), minprop(
         DEFAULT_MINPROP), num_random_splits(DEFAULT_NUM_RANDOM_SPLITS), max_depth(DEFAULT_MAXDEPTH), depth(0), last_left_nodeID(
         0) {
 }
 
-void Tree::init(const Data* data, uint mtry, size_t num_samples, uint seed,
-    std::vector<size_t>* deterministic_varIDs, std::vector<size_t>* split_select_varIDs,
+void Tree::init(const Data* data, uint mtry, size_t num_samples, uint seed, std::vector<size_t>* deterministic_varIDs,
     std::vector<double>* split_select_weights, ImportanceMode importance_mode, uint min_node_size,
     bool sample_with_replacement, bool memory_saving_splitting, SplitRule splitrule, std::vector<double>* case_weights,
     std::vector<size_t>* manual_inbag, bool keep_inbag, std::vector<double>* sample_fraction, double alpha,
-    double minprop, bool holdout, uint num_random_splits, uint max_depth, 
-    std::vector<double>* regularization_factor, bool regularization_usedepth, std::vector<bool>* split_varIDs_used) {
+    double minprop, bool holdout, uint num_random_splits, uint max_depth, std::vector<double>* regularization_factor,
+    bool regularization_usedepth, std::vector<bool>* split_varIDs_used) {
 
   this->data = data;
   this->mtry = mtry;
@@ -58,7 +57,6 @@ void Tree::init(const Data* data, uint mtry, size_t num_samples, uint seed,
   random_number_generator.seed(seed);
 
   this->deterministic_varIDs = deterministic_varIDs;
-  this->split_select_varIDs = split_select_varIDs;
   this->split_select_weights = split_select_weights;
   this->importance_mode = importance_mode;
   this->min_node_size = min_node_size;
@@ -284,7 +282,7 @@ void Tree::createPossibleSplitVarSubset(std::vector<size_t>& result) {
       drawWithoutReplacementSkip(result, random_number_generator, num_vars, (*deterministic_varIDs), mtry);
     }
   } else {
-    drawWithoutReplacementWeighted(result, random_number_generator, *split_select_varIDs, mtry, *split_select_weights);
+    drawWithoutReplacementWeighted(result, random_number_generator, num_vars, mtry, *split_select_weights);
   }
 
   // Always use deterministic variables

--- a/src/Tree.h
+++ b/src/Tree.h
@@ -35,13 +35,13 @@ public:
   Tree(const Tree&) = delete;
   Tree& operator=(const Tree&) = delete;
 
-  void init(const Data* data, uint mtry, size_t num_samples, uint seed,
-      std::vector<size_t>* deterministic_varIDs, std::vector<size_t>* split_select_varIDs,
+  void init(const Data* data, uint mtry, size_t num_samples, uint seed, std::vector<size_t>* deterministic_varIDs,
       std::vector<double>* split_select_weights, ImportanceMode importance_mode, uint min_node_size,
       bool sample_with_replacement, bool memory_saving_splitting, SplitRule splitrule,
       std::vector<double>* case_weights, std::vector<size_t>* manual_inbag, bool keep_inbag,
       std::vector<double>* sample_fraction, double alpha, double minprop, bool holdout, uint num_random_splits,
-      uint max_depth, std::vector<double>* regularization_factor, bool regularization_usedepth, std::vector<bool>* split_varIDs_used);
+      uint max_depth, std::vector<double>* regularization_factor, bool regularization_usedepth,
+      std::vector<bool>* split_varIDs_used);
 
   virtual void allocateMemory() = 0;
 
@@ -161,7 +161,6 @@ protected:
   // Weight vector for selecting possible split variables, one weight between 0 (never select) and 1 (always select) for each variable
   // Deterministic variables are always selected
   const std::vector<size_t>* deterministic_varIDs;
-  const std::vector<size_t>* split_select_varIDs;
   const std::vector<double>* split_select_weights;
 
   // Bootstrap weights

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -186,26 +186,6 @@ void drawWithoutReplacementFisherYates(std::vector<size_t>& result, std::mt19937
 }
 
 void drawWithoutReplacementWeighted(std::vector<size_t>& result, std::mt19937_64& random_number_generator,
-    const std::vector<size_t>& indices, size_t num_samples, const std::vector<double>& weights) {
-
-  result.reserve(num_samples);
-
-  // Set all to not selected
-  std::vector<bool> temp;
-  temp.resize(indices.size(), false);
-
-  std::discrete_distribution<> weighted_dist(weights.begin(), weights.end());
-  for (size_t i = 0; i < num_samples; ++i) {
-    size_t draw;
-    do {
-      draw = weighted_dist(random_number_generator);
-    } while (temp[draw]);
-    temp[draw] = true;
-    result.push_back(indices[draw]);
-  }
-}
-
-void drawWithoutReplacementWeighted(std::vector<size_t>& result, std::mt19937_64& random_number_generator,
     size_t max_index, size_t num_samples, const std::vector<double>& weights) {
 
   result.reserve(num_samples);

--- a/src/utility.h
+++ b/src/utility.h
@@ -212,17 +212,6 @@ void drawWithoutReplacementFisherYates(std::vector<size_t>& result, std::mt19937
     size_t max, const std::vector<size_t>& skip, size_t num_samples);
 
 /**
- * Draw random numers without replacement and with weighted probabilites from vector of indices.
- * @param result Vector to add results to. Will not be cleaned before filling.
- * @param random_number_generator Random number generator
- * @param indices Vector with numbers to draw
- * @param num_samples Number of samples to draw
- * @param weights A weight for each element of indices
- */
-void drawWithoutReplacementWeighted(std::vector<size_t>& result, std::mt19937_64& random_number_generator,
-    const std::vector<size_t>& indices, size_t num_samples, const std::vector<double>& weights);
-
-/**
  * Draw random numers without replacement and with weighted probabilites from 0..n-1.
  * @param result Vector to add results to. Will not be cleaned before filling.
  * @param random_number_generator Random number generator

--- a/tests/testthat/test_splitweights.R
+++ b/tests/testthat/test_splitweights.R
@@ -24,3 +24,14 @@ test_that("always split variables work", {
   expect_silent(ranger(dependent.variable.name = "Species", data = iris, num.trees = 10, 
                        always.split.variables = c("Petal.Length", "Petal.Width"), mtry = 2))
 })
+
+test_that("Tree-wise split select weights work with 0s", {
+  num.trees <- 5
+  weights <- replicate(num.trees, sample(c(0, 0, 0.5, 0.5)), simplify = FALSE)
+  rf <- ranger(Species ~ ., iris, mtry = 2, num.trees = num.trees, 
+               split.select.weights = weights)
+  selected_correctly <- sapply(1:num.trees, function(i) {
+    all(treeInfo(rf, i)[,"splitvarID"] %in% c(which(weights[[i]] > 0) - 1, NA))
+  })
+  expect_true(all(selected_correctly))
+})


### PR DESCRIPTION
Not needed anymore with internal x/y interface. 

Also fixes bug when 0's are in tree-wise `split.select.weights`, reported by @fouodo.