### PR TITLE
Fix order of sample.fraction

### DIFF
--- a/R/ranger.R
+++ b/R/ranger.R
@@ -515,6 +515,8 @@ ranger <- function(formula = NULL, data = NULL, num.trees = 500, mtry = NULL,
     if (!is.null(case.weights)) {
       stop("Error: Combination of case.weights and class-wise sampling not supported.")
     }
+    # Fix order (C++ needs sample.fraction in order as classes appear in data)
+    sample.fraction <- sample.fraction[as.numeric(unique(y))]
   } else {
     if (sample.fraction <= 0 || sample.fraction > 1) {
       stop("Error: Invalid value for sample.fraction. Please give a value in (0,1] or a vector of values in [0,1].")

--- a/src/TreeClassification.cpp
+++ b/src/TreeClassification.cpp
@@ -835,6 +835,7 @@ void TreeClassification::bootstrapWithoutReplacementClassWise() {
     shuffleAndSplitAppend(sampleIDs, oob_sampleIDs, num_samples_class, num_samples_inbag_class,
         (*sampleIDs_per_class)[i], random_number_generator);
   }
+  num_samples_oob = oob_sampleIDs.size();
 
   if (keep_inbag) {
     // All observation are 0 or 1 times inbag

--- a/src/TreeProbability.cpp
+++ b/src/TreeProbability.cpp
@@ -829,6 +829,7 @@ void TreeProbability::bootstrapWithoutReplacementClassWise() {
     shuffleAndSplitAppend(sampleIDs, oob_sampleIDs, num_samples_class, num_samples_inbag_class,
         (*sampleIDs_per_class)[i], random_number_generator);
   }
+  num_samples_oob = oob_sampleIDs.size();
 
   if (keep_inbag) {
     // All observation are 0 or 1 times inbag

--- a/tests/testthat/test_ranger.R
+++ b/tests/testthat/test_ranger.R
@@ -66,17 +66,26 @@ test_that("Inbag counts match sample fraction, classification", {
   rf <- ranger(Species ~ ., iris, num.trees = 5, sample.fraction = c(0.2, 0.3, 0.4), 
                replace = TRUE, keep.inbag = TRUE)
   inbag <- do.call(cbind, rf$inbag.counts)
-  expect_equal(unique(colSums(inbag[1:50, ])), 30)
-  expect_equal(unique(colSums(inbag[51:100, ])), 45)
-  expect_equal(unique(colSums(inbag[101:150, ])), 60)
+  expect_equal(unique(colSums(inbag[iris$Species == "setosa", ])), 30)
+  expect_equal(unique(colSums(inbag[iris$Species == "versicolor", ])), 45)
+  expect_equal(unique(colSums(inbag[iris$Species == "virginica", ])), 60)
   
   ## Without replacement
   rf <- ranger(Species ~ ., iris, num.trees = 5, sample.fraction = c(0.1, 0.2, 0.3), 
                replace = FALSE, keep.inbag = TRUE)
   inbag <- do.call(cbind, rf$inbag.counts)
-  expect_equal(unique(colSums(inbag[1:50, ])), 15)
-  expect_equal(unique(colSums(inbag[51:100, ])), 30)
-  expect_equal(unique(colSums(inbag[101:150, ])), 45)
+  expect_equal(unique(colSums(inbag[iris$Species == "setosa", ])), 15)
+  expect_equal(unique(colSums(inbag[iris$Species == "versicolor", ])), 30)
+  expect_equal(unique(colSums(inbag[iris$Species == "virginica", ])), 45)
+  
+  ## Different order, without replacement
+  dat <- iris[c(51:100, 101:150, 1:50), ]
+  rf <- ranger(Species ~ ., dat, num.trees = 5, sample.fraction = c(0.1, 0.2, 0.3), 
+               replace = FALSE, keep.inbag = TRUE)
+  inbag <- do.call(cbind, rf$inbag.counts)
+  expect_equal(unique(colSums(inbag[dat$Species == "setosa", ])), 15)
+  expect_equal(unique(colSums(inbag[dat$Species == "versicolor", ])), 30)
+  expect_equal(unique(colSums(inbag[dat$Species == "virginica", ])), 45)
 })
 
 test_that("Inbag counts match sample fraction, probability", {


### PR DESCRIPTION
In C++ the order of sample fraction has to be as the order in the data and not the factor levels. 

Fix problem in #480.

Also fixes NaN OOB error for class-wise sampling without replacement.