### PR TITLE
Add shared library and installation for cpp ranger

### DIFF
--- a/cpp_version/CMakeLists.txt
+++ b/cpp_version/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 ## ======================================================================================##
 include_directories(src src/utility src/Forest src/Tree)
 file(GLOB_RECURSE SOURCES src/*/*.cpp)
-file(GLOB_RECURSE HEADERS src/*/*.h)
+file(GLOB_RECURSE HEADERS ../src/*.h)
 
 ## ======================================================================================##
 ## Debug and release targets
@@ -64,6 +64,10 @@ add_library(ranger SHARED ${SOURCES})
 ## Executable
 ## ======================================================================================##
 add_executable(ranger-bin src/main.cpp)
+
+set_target_properties(ranger PROPERTIES
+        PUBLIC_HEADER "${HEADERS}"
+)
 target_link_libraries(ranger-bin ranger)
 set_target_properties(ranger-bin PROPERTIES OUTPUT_NAME ranger)
 
@@ -71,6 +75,5 @@ install(TARGETS
         ranger
         ranger-bin
         RUNTIME DESTINATION bin
-        LIBRARY DESTINATION lib)
-
-install(FILES ${HEADERS} DESTINATION include/ranger)
+        LIBRARY DESTINATION lib
+        PUBLIC_HEADER DESTINATION include/ranger)

--- a/cpp_version/CMakeLists.txt
+++ b/cpp_version/CMakeLists.txt
@@ -33,7 +33,8 @@ endif()
 ## Subdirectories and source files
 ## ======================================================================================##
 include_directories(src src/utility src/Forest src/Tree)
-file(GLOB_RECURSE SOURCES src/*.cpp)
+file(GLOB_RECURSE SOURCES src/*/*.cpp)
+file(GLOB_RECURSE HEADERS src/*/*.h)
 
 ## ======================================================================================##
 ## Debug and release targets
@@ -52,8 +53,24 @@ ADD_CUSTOM_TARGET(release
   COMMENT "Switch CMAKE_BUILD_TYPE to Release"
   )
 
+
+## ======================================================================================##
+## Library
+## ======================================================================================##
+
+add_library(ranger SHARED ${SOURCES})
+
 ## ======================================================================================##
 ## Executable
 ## ======================================================================================##
-add_executable(ranger ${SOURCES})
+add_executable(ranger-bin src/main.cpp)
+target_link_libraries(ranger-bin ranger)
+set_target_properties(ranger-bin PROPERTIES OUTPUT_NAME ranger)
 
+install(TARGETS
+        ranger
+        ranger-bin
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib)
+
+install(FILES ${HEADERS} DESTINATION include/ranger)


### PR DESCRIPTION
Generates a shared library
Installs the shared library, binaries and headers.

This commit allows third-parties to use ranger as a library and provides a standard mechanism for installing binaries and libraries.