### PR TITLE
Fix memory mode initialization

### DIFF
--- a/src/Forest.cpp
+++ b/src/Forest.cpp
@@ -48,6 +48,7 @@ void Forest::initCpp(std::string dependent_variable_name, MemoryMode memory_mode
     PredictionType prediction_type, uint num_random_splits, uint max_depth,
     const std::vector<double>& regularization_factor, bool regularization_usedepth) {
 
+  this->memory_mode = memory_mode;
   this->verbose_out = verbose_out;
 
   if (!dependent_variable_name.empty()) {
@@ -79,7 +80,7 @@ void Forest::initCpp(std::string dependent_variable_name, MemoryMode memory_mode
   }
 
   // Call other init function
-  init(memory_mode, loadDataFromFile(input_file), mtry, output_prefix, num_trees, seed, num_threads, importance_mode,
+  init(loadDataFromFile(input_file), mtry, output_prefix, num_trees, seed, num_threads, importance_mode,
       min_node_size, prediction_mode, sample_with_replacement, unordered_variable_names, memory_saving_splitting,
       splitrule, predict_all, sample_fraction_vector, alpha, minprop, holdout, prediction_type, num_random_splits,
       false, max_depth, regularization_factor, regularization_usedepth);
@@ -143,10 +144,11 @@ void Forest::initR(std::unique_ptr<Data> input_data, uint mtry, uint num_trees, 
     uint num_random_splits, bool order_snps, uint max_depth, const std::vector<double>& regularization_factor,
     bool regularization_usedepth) {
 
+  this->memory_mode = memory_mode;
   this->verbose_out = verbose_out;
 
   // Call other init function
-  init(MEM_DOUBLE, std::move(input_data), mtry, "", num_trees, seed, num_threads, importance_mode, min_node_size,
+  init(std::move(input_data), mtry, "", num_trees, seed, num_threads, importance_mode, min_node_size,
       prediction_mode, sample_with_replacement, unordered_variable_names, memory_saving_splitting, splitrule,
       predict_all, sample_fraction, alpha, minprop, holdout, prediction_type, num_random_splits, order_snps, max_depth,
       regularization_factor, regularization_usedepth);
@@ -178,7 +180,7 @@ void Forest::initR(std::unique_ptr<Data> input_data, uint mtry, uint num_trees, 
   this->keep_inbag = keep_inbag;
 }
 
-void Forest::init(MemoryMode memory_mode, std::unique_ptr<Data> input_data, uint mtry, std::string output_prefix,
+void Forest::init(std::unique_ptr<Data> input_data, uint mtry, std::string output_prefix,
     uint num_trees, uint seed, uint num_threads, ImportanceMode importance_mode, uint min_node_size,
     bool prediction_mode, bool sample_with_replacement, const std::vector<std::string>& unordered_variable_names,
     bool memory_saving_splitting, SplitRule splitrule, bool predict_all, std::vector<double>& sample_fraction,
@@ -214,7 +216,6 @@ void Forest::init(MemoryMode memory_mode, std::unique_ptr<Data> input_data, uint
   this->output_prefix = output_prefix;
   this->importance_mode = importance_mode;
   this->min_node_size = min_node_size;
-  this->memory_mode = memory_mode;
   this->prediction_mode = prediction_mode;
   this->sample_with_replacement = sample_with_replacement;
   this->memory_saving_splitting = memory_saving_splitting;

--- a/src/Forest.h
+++ b/src/Forest.h
@@ -58,7 +58,7 @@ public:
       bool keep_inbag, std::vector<double>& sample_fraction, double alpha, double minprop, bool holdout,
       PredictionType prediction_type, uint num_random_splits, bool order_snps, uint max_depth,
       const std::vector<double>& regularization_factor, bool regularization_usedepth);
-  void init(MemoryMode memory_mode, std::unique_ptr<Data> input_data, uint mtry, std::string output_prefix,
+  void init(std::unique_ptr<Data> input_data, uint mtry, std::string output_prefix,
       uint num_trees, uint seed, uint num_threads, ImportanceMode importance_mode, uint min_node_size,
       bool prediction_mode, bool sample_with_replacement, const std::vector<std::string>& unordered_variable_names,
       bool memory_saving_splitting, SplitRule splitrule, bool predict_all, std::vector<double>& sample_fraction,


### PR DESCRIPTION
This was previously set by `init`, which gets called after `loadDataFromFile`, meaning that it defaulted to `double`.