### PR TITLE
Much faster permutation variable importance calculation for high-dimensional data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: ranger
 Type: Package
 Title: A Fast Implementation of Random Forests
-Version: 0.13.2
-Date: 2022-03-03
+Version: 0.13.3
+Date: 2022-05-25
 Author: Marvin N. Wright [aut, cre], Stefan Wager [ctb], Philipp Probst [ctb]
 Maintainer: Marvin N. Wright <cran@wrig.de>
 Description: A fast implementation of Random Forests, particularly suited for high

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
 
+# ranger 0.13.3
+* Faster permutation variable importance for high dimensional data (thanks to Roman Hornung)
+
 # ranger 0.13.2
 * Add deforest() function to remove trees from ensemble
 * Fix cross compiling for Windows

--- a/cpp_version/src/version.h
+++ b/cpp_version/src/version.h
@@ -1,3 +1,3 @@
 #ifndef RANGER_VERSION
-#define RANGER_VERSION "0.13.2"
+#define RANGER_VERSION "0.13.3"
 #endif

--- a/src/Tree.cpp
+++ b/src/Tree.cpp
@@ -227,6 +227,34 @@ void Tree::computePermutationImportance(std::vector<double>& forest_importance, 
   // Randomly permute for all independent variables
   for (size_t i = 0; i < num_independent_variables; ++i) {
 
+     // Check whether the i-th variable is used in the
+	 // tree:
+     bool isused = false;
+     for (size_t j = 0; j < split_varIDs.size(); ++j)
+     {
+        if (split_varIDs[j] == i)
+        {
+          isused = true;
+          break;
+        }
+     }
+     
+	 // Only if the variable is used in the tree, the OOB predictions
+	 // can possibly change by permuting the OOB observations.
+	 // Therefore, we only need to permute the OOB observations and
+	 // re-calculate the predictions, if the variable is used in the tree.
+	 // Otherwise 'accuracy_normal' and 'accuracy_permuted' would
+	 // be the same, which is why their difference would be zero
+	 // and we would correspondlgy add nothing (zero) to the sum 'forest_importance[i]'
+	 // of the differences between the accuracies 'accuracy_normal' and
+	 // 'accuracy_permuted'.
+	 // Therefore, the following part is only performed if the variable
+	 // is used in the tree (this condition makes the computations much
+	 // less expensive, in particular for high-dimensional data because
+	 // here most variables will not be used in most trees):
+     if (isused)
+     {
+
     // Permute and compute prediction accuracy again for this permutation and save difference
     permuteAndPredictOobSamples(i, permutations);
     double accuracy_permuted;
@@ -249,6 +277,9 @@ void Tree::computePermutationImportance(std::vector<double>& forest_importance, 
     } else if (importance_mode == IMP_PERM_LIAW) {
       forest_variance[i] += accuracy_difference * accuracy_difference * num_samples_oob;
     }
+	
+	}
+	
   }
 }
 


### PR DESCRIPTION
**A small change that allows for a much faster permutation variable importance calculation for high-dimensional data**

For high-dimensional data, the calculation of the permutation variable importance was very slow. This issue is fixed here by a small change that allows a much faster calculation without affecting the calculated variable importance scores.

When calculating the permutation variable importance of a variable, if that variable is not used in a tree, the OOB predictions of the tree are not affected by permuting the OOB values of the variable. Exploiting the latter fact, in the small change presented here, the OOB values of a variable are only permuted and the OOB predictions re-calculated for those trees which use this variable. This small change becomes important for higher dimensional data because for such data most variables will only be used in a small proportion of the trees (if at all). Therefore, permuting the OOB values and re-calculating the OOB predictions only for the trees that use the respective variables leads to a huge saving in computing cost for high-dimensional data.

For example, in a test for a data set with 382 observations and 382,711 variables (DNA methylation data) with survival outcome the computations were more than 100 times faster after the change described above! (The run time before the change was 93.6 minutes (1.56 hours) and after the change it was 0.85 minutes; `num.trees = 1000`; `splitrule = "extratrees"`)