### PR TITLE
fixed typo sepErat* to sepArat*

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ In the C++ version type
 ./ranger --help 
 ```
 
-for a list of commands. First you need a training dataset in a file. This file should contain one header line with variable names and one line with variable values per sample (numeric only). Variable names must not contain any whitespace, comma or semicolon. Values can be seperated by whitespace, comma or semicolon but can not be mixed in one file. A typical call of ranger would be for example
+for a list of commands. First you need a training dataset in a file. This file should contain one header line with variable names and one line with variable values per sample (numeric only). Variable names must not contain any whitespace, comma or semicolon. Values can be separated by whitespace, comma or semicolon but can not be mixed in one file. A typical call of ranger would be for example
 
 ```bash
 ./ranger --verbose --file data.dat --depvarname Species --treetype 1 --ntree 1000 --nthreads 4

--- a/src/Data.cpp
+++ b/src/Data.cpp
@@ -63,11 +63,11 @@ bool Data::loadFromFile(std::string filename, std::vector<std::string>& dependen
   input_file.close();
   input_file.open(filename);
 
-  // Check if comma, semicolon or whitespace seperated
+  // Check if comma, semicolon or whitespace separated
   std::string header_line;
   getline(input_file, header_line);
 
-  // Find out if comma, semicolon or whitespace seperated and call appropriate method
+  // Find out if comma, semicolon or whitespace separated and call appropriate method
   if (header_line.find(',') != std::string::npos) {
     result = loadFromFileOther(input_file, header_line, dependent_variable_names, ',');
   } else if (header_line.find(';') != std::string::npos) {
@@ -150,7 +150,7 @@ bool Data::loadFromFileWhitespace(std::ifstream& input_file, std::string header_
 }
 
 bool Data::loadFromFileOther(std::ifstream& input_file, std::string header_line,
-    std::vector<std::string>& dependent_variable_names, char seperator) {
+    std::vector<std::string>& dependent_variable_names, char separator) {
 
   size_t num_dependent_variables = dependent_variable_names.size();
   std::vector<size_t> dependent_varIDs;
@@ -160,7 +160,7 @@ bool Data::loadFromFileOther(std::ifstream& input_file, std::string header_line,
   std::string header_token;
   std::stringstream header_line_stream(header_line);
   size_t col = 0;
-  while (getline(header_line_stream, header_token, seperator)) {
+  while (getline(header_line_stream, header_token, separator)) {
     bool is_dependent_var = false;
     for (size_t i = 0; i < dependent_variable_names.size(); ++i) {
       if (header_token == dependent_variable_names[i]) {
@@ -187,7 +187,7 @@ bool Data::loadFromFileOther(std::ifstream& input_file, std::string header_line,
     double token;
     std::stringstream line_stream(line);
     size_t column = 0;
-    while (getline(line_stream, token_string, seperator)) {
+    while (getline(line_stream, token_string, separator)) {
       std::stringstream token_stream(token_string);
       readFromStream(token_stream, token);
 

--- a/src/Data.h
+++ b/src/Data.h
@@ -47,7 +47,7 @@ public:
   bool loadFromFileWhitespace(std::ifstream& input_file, std::string header_line,
       std::vector<std::string>& dependent_variable_names);
   bool loadFromFileOther(std::ifstream& input_file, std::string header_line,
-      std::vector<std::string>& dependent_variable_names, char seperator);
+      std::vector<std::string>& dependent_variable_names, char separator);
 
   void getAllValues(std::vector<double>& all_values, std::vector<size_t>& sampleIDs, size_t varID, size_t start,
       size_t end) const;


### PR DESCRIPTION
# Changes
I noticed some misspellings of "separate", "separated".

Hope this helps!

# Tests
ran ./runUnitTests locally without errors