### PR TITLE
Fixes #656

### DIFF
--- a/src/Forest.cpp
+++ b/src/Forest.cpp
@@ -967,8 +967,8 @@ void Forest::setSplitWeightVector(std::vector<std::vector<double>>& split_select
   
   // Deterministic varIDs 
   std::vector<bool> is_deterministic(num_weights, false);
-  for (size_t i = 0; i < deterministic_varIDs.size(); ++i) {
-    is_deterministic[i] = true;
+  for (auto it = deterministic_varIDs.cbegin(); it != deterministic_varIDs.cend(); ++it) {
+    is_deterministic[*it] = true;
   }
 
   // Split up in deterministic and weighted variables, ignore zero weights

--- a/tests/testthat/test_splitweights.R
+++ b/tests/testthat/test_splitweights.R
@@ -45,3 +45,15 @@ test_that("Tree-wise split select weights work with 0s", {
   })
   expect_true(all(selected_correctly))
 })
+
+test_that("always split variables respect split select weights", {
+    iris_vars <- setdiff(names(iris), 'Species')
+    n_vars <- length(iris_vars)
+    last_var <- iris_vars[n_vars]
+    with_last_zero <- c(rep(1, n_vars-1), 0)
+    expect_silent(
+        ranger(Species ~ ., iris, num.trees=5,
+               always.split.variables=last_var, mtry=n_vars-1,
+               split.select.weights=with_last_zero)
+    )
+})


### PR DESCRIPTION
Proposed fix for always.split.variables and split.select.weights and a test which covers the previously-failing use cases.