### PR TITLE
Add dependabot.yml to auto-update github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+
+updates:
+  # Keep dependencies for GitHub Actions up-to-date
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
This automatically creates a pull request to update used github actions used in existing workflows once per month.

For example, if `r-lib/actions/setup-r@v2` was updated to a `v3`.
