### PR TITLE
CMake: Bump minimum version

### DIFF
--- a/cpp_version/CMakeLists.txt
+++ b/cpp_version/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.13)
 project(ranger)
 include (GNUInstallDirs)
 


### PR DESCRIPTION
Rationale: cmake 4.0 deprecated support for versions less than 3.10