### PR TITLE
Forest::loadDataForPrediction

### DIFF
--- a/src/Forest.cpp
+++ b/src/Forest.cpp
@@ -281,6 +281,26 @@ void Forest::init(std::unique_ptr<Data> input_data, uint mtry, std::string outpu
   }
 }
 
+void Forest::loadDataForPrediction(std::unique_ptr<Data> input_data, std::vector<bool>& is_ordered_variable, bool predict_all) {
+  this->data = std::move(input_data);
+  this->prediction_mode = true;
+  this->predict_all = predict_all;
+
+  // Set number of samples and variables
+  num_samples = data->getNumRows();
+  num_independent_variables = data->getNumCols();
+
+  // Set unordered factor variables
+  data->setIsOrderedVariable(is_ordered_variable);
+
+  initInternal();
+
+  // Permute samples for corrected Gini importance
+  if (importance_mode == IMP_GINI_CORRECTED) {
+    data->permuteSampleIDs(random_number_generator);
+  }
+}
+
 void Forest::run(bool verbose, bool compute_oob_error) {
 
   if (prediction_mode) {

--- a/src/Forest.h
+++ b/src/Forest.h
@@ -65,6 +65,7 @@ public:
       bool order_snps, uint max_depth, const std::vector<double>& regularization_factor, bool regularization_usedepth,
       bool node_stats);
   virtual void initInternal() = 0;
+  void loadDataForPrediction(std::unique_ptr<Data> input_data, std::vector<bool>& is_ordered_variable, bool predict_all = false);
 
   // Grow or predict
   void run(bool verbose, bool compute_oob_error);


### PR DESCRIPTION
This PR proposes a small addition to the Forest class: a `loadDataForPrediction` method to load data for an already trained Forest without having to call the `Forest::initR` method.

I am proposing this because I am trying to wrap the C++ core of Ranger into [OpenTURNS](https://github.com/openturns/openturns) (I have a [prototype here](https://github.com/josephmure/openturns/commit/5c7283ec288c532d0ed04d02e6ff9b162d63f510)) and this feature would be useful.

Maybe it could also help solve https://github.com/imbs-hl/ranger/issues/133#issuecomment-392047642

One thing I am wondering is whether  `Forest::initInternal` needs to be called in prediction mode. I made `Forest::loadDataForPrediction` call it to try to be on the safe side, but I am not sure whether it is necessary.