### PR TITLE
Fix partial matches in tests and internal `quantile()` call

### DIFF
--- a/R/utility.R
+++ b/R/utility.R
@@ -66,7 +66,7 @@ largest.quantile <- function(formula) {
   
   ## Use median survival if available or largest quantile available in all strata if median not available
   max_quant <- max(aggregate(smry$surv ~ smry$strata, FUN = min)[, "smry$surv"])
-  quantiles <- quantile(fit, conf.int = FALSE, prob = min(0.5, 1 - max_quant))[, 1]
+  quantiles <- quantile(fit, conf.int = FALSE, probs = min(0.5, 1 - max_quant))[, 1]
   names(quantiles) <- gsub(".+=", "", names(quantiles))
   
   ## Return ordered levels

--- a/tests/testthat/test_interface.R
+++ b/tests/testthat/test_interface.R
@@ -60,13 +60,13 @@ test_that("Error if interaction of factor variable included", {
 test_that("Working if dependent variable has attributes other than names", {
   iris2 <- iris
   attr(iris2$Sepal.Width, "aaa") <- "bbb"
-  expect_silent(ranger(data = iris2, dependent.variable = "Sepal.Width"))
+  expect_silent(ranger(data = iris2, dependent.variable.name = "Sepal.Width"))
 })
 
 test_that("Working if dependent variable is matrix with one column", {
   iris2 <- iris
   iris2$Sepal.Width = scale(iris$Sepal.Width)
-  expect_silent(ranger(data = iris2, dependent.variable = "Sepal.Width"))
+  expect_silent(ranger(data = iris2, dependent.variable.name = "Sepal.Width"))
 })
 
 test_that("Same result with x/y interface, classification", {

--- a/tests/testthat/test_ranger.R
+++ b/tests/testthat/test_ranger.R
@@ -347,28 +347,28 @@ test_that("min.bucket creates nodes of correct size", {
   # Size 2
   rf <- ranger(Species ~ ., iris, num.trees = 5, replace = FALSE, 
                min.bucket = 2, keep.inbag = TRUE)
-  pred <- predict(rf, iris, type = "terminalNodes")$prediction
+  pred <- predict(rf, iris, type = "terminalNodes")$predictions
   inbag <- sapply(rf$inbag.counts, function(x) x == 1)
   smallest_node <- min(sapply(1:ncol(pred), function(i) {
     min(table(pred[inbag[, i], i]))
   }))
   expect_gte(smallest_node, 2)
-  
+
   # Size 10
-  rf <- ranger(Species ~ ., iris, num.trees = 5, replace = FALSE, 
+  rf <- ranger(Species ~ ., iris, num.trees = 5, replace = FALSE,
                min.bucket = 10, keep.inbag = TRUE)
-  pred <- predict(rf, iris, type = "terminalNodes")$prediction
+  pred <- predict(rf, iris, type = "terminalNodes")$predictions
   inbag <- sapply(rf$inbag.counts, function(x) x == 1)
   smallest_node <- min(sapply(1:ncol(pred), function(i) {
     min(table(pred[inbag[, i], i]))
   }))
   expect_gte(smallest_node, 10)
-  
+
   # Random size
   min.bucket <- round(runif(1, 1, 40))
-  rf <- ranger(Species ~ ., iris, num.trees = 5, replace = FALSE, 
+  rf <- ranger(Species ~ ., iris, num.trees = 5, replace = FALSE,
                min.bucket = min.bucket, keep.inbag = TRUE)
-  pred <- predict(rf, iris, type = "terminalNodes")$prediction
+  pred <- predict(rf, iris, type = "terminalNodes")$predictions
   inbag <- sapply(rf$inbag.counts, function(x) x == 1)
   smallest_node <- min(sapply(1:ncol(pred), function(i) {
     min(table(pred[inbag[, i], i]))
@@ -381,7 +381,7 @@ test_that("Vector min.bucket creates nodes of correct size", {
   # Size 2,3,4
   rf <- ranger(Species ~ ., iris, num.trees = 5, replace = FALSE, 
                min.bucket = c(2, 3, 4), keep.inbag = TRUE)
-  pred <- predict(rf, iris, type = "terminalNodes")$prediction
+  pred <- predict(rf, iris, type = "terminalNodes")$predictions
   inbag <- sapply(rf$inbag.counts, function(x) x == 1)
   
   smallest_nodes <- sapply(1:ncol(pred), function(i) {
@@ -400,7 +400,7 @@ test_that("Vector min.bucket creates nodes of correct size", {
   # Size 4,3,2
   rf <- ranger(Species ~ ., iris, num.trees = 5, replace = FALSE, 
                min.bucket = c(4, 3, 2), keep.inbag = TRUE)
-  pred <- predict(rf, iris, type = "terminalNodes")$prediction
+  pred <- predict(rf, iris, type = "terminalNodes")$predictions
   inbag <- sapply(rf$inbag.counts, function(x) x == 1)
   
   smallest_nodes <- sapply(1:ncol(pred), function(i) {
@@ -420,7 +420,7 @@ test_that("Vector min.bucket creates nodes of correct size", {
   min.bucket <- round(runif(3, 1, 10))
   rf <- ranger(Species ~ ., iris, num.trees = 5, replace = FALSE, 
                min.bucket = min.bucket, keep.inbag = TRUE)
-  pred <- predict(rf, iris, type = "terminalNodes")$prediction
+  pred <- predict(rf, iris, type = "terminalNodes")$predictions
   inbag <- sapply(rf$inbag.counts, function(x) x == 1)
   
   smallest_nodes <- sapply(1:ncol(pred), function(i) {
@@ -439,7 +439,7 @@ test_that("Vector min.bucket creates nodes of correct size", {
   # No factor outcome
   rf <- ranger(Species ~ ., data.matrix(iris), num.trees = 5, replace = FALSE, 
                min.bucket = c(2, 3, 4), keep.inbag = TRUE, classification = TRUE)
-  pred <- predict(rf, iris, type = "terminalNodes")$prediction
+  pred <- predict(rf, iris, type = "terminalNodes")$predictions
   inbag <- sapply(rf$inbag.counts, function(x) x == 1)
   
   smallest_nodes <- sapply(1:ncol(pred), function(i) {

--- a/tests/testthat/test_survival.R
+++ b/tests/testthat/test_survival.R
@@ -8,9 +8,9 @@ context("ranger_surv")
 rg.surv <- ranger(Surv(time, status) ~ ., data = veteran, num.trees = 10)
 
 ## Basic tests (for all random forests equal)
-test_that("survival result is of class ranger with 19 elements", {
+test_that("survival result is of class ranger with 18 elements", {
   expect_is(rg.surv, "ranger")
-  expect_equal(length(rg.surv), 19)
+  expect_equal(length(rg.surv), 18)
 })
 
 test_that("results have right number of trees", {
@@ -119,11 +119,10 @@ test_that("Survival error without covariates", {
                "Error: No covariates found.")
 })
 
-test_that("Competing risk data works with y/x interface", {
-  sobj <- Surv(veteran$time, factor(sample(0:2, nrow(veteran), replace = TRUE)))
-  rf <- ranger(y = sobj, x = veteran[, 1:2], num.trees = 5)
-  expect_is(rf, "ranger")
-  expect_equal(rf$treetype, "Survival")
+test_that("Survival error for competing risk data", {
+  sobj <- Surv(veteran$time, factor(sample(1:3, nrow(veteran), replace = TRUE)))
+  expect_error(ranger(y = sobj, x = veteran[, 1:2], num.trees = 5), 
+               "Error: Competing risks not supported yet\\. Use status=1 for events and status=0 for censoring\\.")
 })
 
 test_that("Right unique time points without time.interest", {

--- a/tests/testthat/test_survival.R
+++ b/tests/testthat/test_survival.R
@@ -8,9 +8,9 @@ context("ranger_surv")
 rg.surv <- ranger(Surv(time, status) ~ ., data = veteran, num.trees = 10)
 
 ## Basic tests (for all random forests equal)
-test_that("survival result is of class ranger with 18 elements", {
+test_that("survival result is of class ranger with 19 elements", {
   expect_is(rg.surv, "ranger")
-  expect_equal(length(rg.surv), 18)
+  expect_equal(length(rg.surv), 19)
 })
 
 test_that("results have right number of trees", {
@@ -119,10 +119,11 @@ test_that("Survival error without covariates", {
                "Error: No covariates found.")
 })
 
-test_that("Survival error for competing risk data", {
-  sobj <- Surv(veteran$time, factor(sample(1:3, nrow(veteran), replace = TRUE)))
-  expect_error(ranger(y = sobj, x = veteran[, 1:2], num.trees = 5), 
-               "Error: Competing risks not supported yet\\. Use status=1 for events and status=0 for censoring\\.")
+test_that("Competing risk data works with y/x interface", {
+  sobj <- Surv(veteran$time, factor(sample(0:2, nrow(veteran), replace = TRUE)))
+  rf <- ranger(y = sobj, x = veteran[, 1:2], num.trees = 5)
+  expect_is(rf, "ranger")
+  expect_equal(rf$treetype, "Survival")
 })
 
 test_that("Right unique time points without time.interest", {


### PR DESCRIPTION
Found these because I ran tests while having partial argument warnings enabled

```r
options(
	warnPartialMatchArgs = TRUE,
	warnPartialMatchAttr = TRUE,
	warnPartialMatchDollar = TRUE
)
```