### PR TITLE
Fix calibrateEB interpolation threshold condition

### DIFF
--- a/R/infinitesimalJackknife.R
+++ b/R/infinitesimalJackknife.R
@@ -197,7 +197,7 @@ calibrateEB = function(vars, sigma2) {
   sigma = sqrt(sigma2)
   eb.prior = gfit(vars, sigma)
   
-  if (length(vars >= 200)) {
+  if (length(vars) >= 200) {
     # If there are many test points, use interpolation to speed up computations
     calib.x = unique(quantile(vars, q = seq(0, 1, by = 0.02)))
     calib.y = sapply(calib.x, function(xx) gbayes(xx, eb.prior, sigma))

--- a/tests/testthat/test_jackknife.R
+++ b/tests/testthat/test_jackknife.R
@@ -195,3 +195,32 @@ test_that("Standard error prediction working for single observation, probability
   pred <- expect_warning(predict(rf, test, type = "se", se.method = "infjack"))
   expect_equal(dim(pred$se), c(1, 3))
 })
+
+test_that("calibrateEB uses exact branch below 200 and interpolation at/above 200", {
+  # Regression test: previously `length(vars >= 200)` made the interpolation
+  # branch run for every non-empty input, leaving the intended exact branch
+  # dead. The correct condition is `length(vars) >= 200`.
+  set.seed(42)
+  sigma2 <- 0.1
+  sigma <- sqrt(sigma2)
+
+  # Below the threshold: the exact per-observation branch must be used.
+  vars_small <- runif(199, 0.01, 2)
+  res_small <- ranger:::calibrateEB(vars_small, sigma2)
+  expect_length(res_small, 199)
+  expect_true(all(is.finite(res_small)))
+  expect_true(all(res_small >= 0))
+  # A direct gbayes evaluation per observation (no interpolation) must match,
+  # which only holds when the exact branch is taken.
+  eb_prior <- ranger:::gfit(vars_small, sigma)
+  exact_small <- sapply(vars_small, function(xx) ranger:::gbayes(xx, eb_prior, sigma))
+  expect_equal(res_small, exact_small, tolerance = 1e-8)
+
+  # At/above the threshold: the interpolation branch is used. Only sanity-check
+  # the output (interpolation introduces approximation, so no exact assertions).
+  vars_large <- runif(200, 0.01, 2)
+  res_large <- ranger:::calibrateEB(vars_large, sigma2)
+  expect_length(res_large, 200)
+  expect_true(all(is.finite(res_large)))
+  expect_true(all(res_large >= 0))
+})


### PR DESCRIPTION
calibrateEB() chooses between an exact gbayes() evaluation and a faster interpolation according to the number of variance estimates. The condition `length(vars >= 200)` measured the comparison result rather than vars, so it was true for every non-empty input and left the exact branch unreachable.

Use `length(vars) >= 200`, as described by the existing comment, so inputs below the threshold use the exact calculation. Both paths target the same posterior, so the practical numerical difference is small.

Add regression coverage for exact evaluation below the threshold and a sanity check of interpolation at the threshold.

Found during my https://github.com/sims1253/ry audit